### PR TITLE
Trip Destination Alts Preprocessor

### DIFF
--- a/configs/resident/trip_destination.csv
+++ b/configs/resident/trip_destination.csv
@@ -6,7 +6,7 @@ local_dist_nd,,_nd_DIST@nd_skims['DIST'],1,1,1,1,1,1,1,1,1,1
 distance_deviation,distance deviation,_dist_dev@(_od_DIST +_dp_DIST - _op_DIST),1,1,1,1,1,1,1,1,1,1
 dist_deviation_logged,logged deviation distance,"_dist_dev_logged@np.where((_dist_dev > 0), np.log(_dist_dev),0)",1,1,1,1,1,1,1,1,1,1
 #,,,,,,,,,,,,
-util_sizeterm,size term,"@np.log1p(size_terms.get(df.dest_taz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
+util_sizeterm,size term,"@np.log1p(size_terms.get(df.dest_maz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
 util_Sampleofalternativescorrectionfactor,Sample of alternatives correction factor,"@np.minimum(np.log(df.pick_count/df.prob), 60)",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
 util_Modechoicelogsum,Mode choice logsum,od_logsum + dp_logsum,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr
 #,,,,,,,,,,,,

--- a/configs/resident/trip_destination.csv
+++ b/configs/resident/trip_destination.csv
@@ -6,7 +6,7 @@ local_dist_nd,,_nd_DIST@nd_skims['DIST'],1,1,1,1,1,1,1,1,1,1
 distance_deviation,distance deviation,_dist_dev@(_od_DIST +_dp_DIST - _op_DIST),1,1,1,1,1,1,1,1,1,1
 dist_deviation_logged,logged deviation distance,"_dist_dev_logged@np.where((_dist_dev > 0), np.log(_dist_dev),0)",1,1,1,1,1,1,1,1,1,1
 #,,,,,,,,,,,,
-util_sizeterm,size term,"@np.log1p(size_terms.get(df.dest_maz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
+util_sizeterm,size term,"@np.log1p(size_terms.get(df.alt_dest, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
 util_Sampleofalternativescorrectionfactor,Sample of alternatives correction factor,"@np.minimum(np.log(df.pick_count/df.prob), 60)",coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one,coef_one
 util_Modechoicelogsum,Mode choice logsum,od_logsum + dp_logsum,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_mandatory,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_maint,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr,coef_mode_choice_logsum_discr
 #,,,,,,,,,,,,

--- a/configs/resident/trip_destination.yaml
+++ b/configs/resident/trip_destination.yaml
@@ -17,7 +17,7 @@ DEST_CHOICE_SAMPLE_TABLE_NAME: trip_destination_sample
 
 # model-specific logsum-related settings
 TRIP_ORIGIN: origin
-ALT_DEST_COL_NAME: dest_maz
+ALT_DEST_COL_NAME: alt_dest
 PRIMARY_ORIGIN: tour_leg_origin
 PRIMARY_DEST: tour_leg_dest # must be created in preprocessor
 
@@ -35,11 +35,19 @@ preprocessor:
     - households
     - land_use
 
-alts_preprocessor:
-  SPEC: trip_destination_annotate_alts_preprocessor
-  DF: trips
+# preprocessor for sample, operates on TAZs
+alts_preprocessor_sample:
+  SPEC: trip_destination_annotate_alts_preprocessor_sample
+  DF: alternatives
   TABLES:
     - land_use
+
+# preprocessor for simulate, operates on MAZs in two zone models
+# alts_preprocessor_sample:
+#   SPEC: trip_destination_annotate_alts_preprocessor_simulate
+#   DF: alternatives
+#   TABLES:
+#     - land_use
 
 
 # drop failed trips and cleanup failed trip leg_mates for consistency

--- a/configs/resident/trip_destination.yaml
+++ b/configs/resident/trip_destination.yaml
@@ -25,9 +25,7 @@ PRIMARY_DEST: tour_leg_dest # must be created in preprocessor
 # (it is assigned in trip_destination_annotate_trips_preprocessor )
 REDUNDANT_TOURS_MERGED_CHOOSER_COLUMNS:
   - tour_mode
-  
 
-  
 preprocessor:
   SPEC: trip_destination_annotate_trips_preprocessor
   DF: trips
@@ -35,6 +33,12 @@ preprocessor:
     - tours
     - persons
     - households
+    - land_use
+
+alts_preprocessor:
+  SPEC: trip_destination_annotate_alts_preprocessor
+  DF: trips
+  TABLES:
     - land_use
 
 

--- a/configs/resident/trip_destination.yaml
+++ b/configs/resident/trip_destination.yaml
@@ -17,7 +17,7 @@ DEST_CHOICE_SAMPLE_TABLE_NAME: trip_destination_sample
 
 # model-specific logsum-related settings
 TRIP_ORIGIN: origin
-ALT_DEST_COL_NAME: dest_taz
+ALT_DEST_COL_NAME: dest_maz
 PRIMARY_ORIGIN: tour_leg_origin
 PRIMARY_DEST: tour_leg_dest # must be created in preprocessor
 

--- a/configs/resident/trip_destination_annotate_alts_preprocessor.csv
+++ b/configs/resident/trip_destination_annotate_alts_preprocessor.csv
@@ -1,2 +1,0 @@
-Description,Target,Expression
-micromobility access time at destination,d_microAccTime,"land_use['MicroAccessTime'].reindex(df.index)"

--- a/configs/resident/trip_destination_annotate_alts_preprocessor.csv
+++ b/configs/resident/trip_destination_annotate_alts_preprocessor.csv
@@ -1,0 +1,2 @@
+Description,Target,Expression
+max micromobility access time at destination,d_microAccTime,"land_use.sort_values(by='MicroAccessTime',ascending=False).drop_duplicates('TAZ',keep='first').set_index('TAZ')['MicroAccessTime'].reindex(df.index)"

--- a/configs/resident/trip_destination_annotate_alts_preprocessor.csv
+++ b/configs/resident/trip_destination_annotate_alts_preprocessor.csv
@@ -1,2 +1,2 @@
 Description,Target,Expression
-max micromobility access time at destination,d_microAccTime,"land_use.sort_values(by='MicroAccessTime',ascending=False).drop_duplicates('TAZ',keep='first').set_index('TAZ')['MicroAccessTime'].reindex(df.index)"
+micromobility access time at destination,d_microAccTime,"land_use['MicroAccessTime'].reindex(df.index)"

--- a/configs/resident/trip_destination_annotate_alts_preprocessor_sample.csv
+++ b/configs/resident/trip_destination_annotate_alts_preprocessor_sample.csv
@@ -1,0 +1,2 @@
+Description,Target,Expression
+micromobility access time at destination taz,d_microAccTime,"land_use.groupby('TAZ')['MicroAccessTime'].agg('max').reindex(df.index)"

--- a/configs/resident/trip_destination_sample.csv
+++ b/configs/resident/trip_destination_sample.csv
@@ -4,8 +4,6 @@ Description,Expression,work,univ,school,escort,shopping,eatout,othmaint,social,o
 ,_op_DIST@op_skims['DIST'],1,1,1,1,1,1,1,1,1,1
 ,_od_bikeL@odt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
 ,_dp_bikeL@dpt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
-# next line gets max MAZ micromobility access time in destination TAZ
-,"_d_microAccTime@land_use.sort_values(by='MicroAccessTime',ascending=False).drop_duplicates('TAZ',keep='first').set_index('TAZ')['MicroAccessTime'].reindex(df.dest_taz)",1,1,1,1,1,1,1,1,1,1
 #,,,,,,,,,,,
 size term,"@np.log1p(size_terms.get(df.dest_taz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",1,1,1,1,1,1,1,1,1,1
 no attractions,"@size_terms.get(df.dest_taz, df.purpose) == 0 # sharrow: size_terms['sizearray'] == 0",-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
@@ -19,4 +17,4 @@ no attractions,"@size_terms.get(df.dest_taz, df.purpose) == 0 # sharrow: size_te
 ,@df.bikeTour * (_dp_bikeL < -300),-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
 #,,,,,,,,,,,
 ,@(df.nonmotorTour==0) * (_od_DIST  +  _dp_DIST - _op_DIST),-0.05,-0.05,-0.05,-0.05,-0.05,-0.05,-0.05,-0.05,-0.05,-0.05
-,"@(df.microTour * (np.where(_d_microAccTime > microAccessThreshold,1,0) + np.where(df.o_MicroAccessTime > microAccessThreshold,1,0)))",-10,-10,-10,-10,-10,-10,-10,-10,-10,-10
+,"@(df.microTour * (np.where(df.d_microAccTime > microAccessThreshold,1,0) + np.where(df.o_MicroAccessTime > microAccessThreshold,1,0)))",-10,-10,-10,-10,-10,-10,-10,-10,-10,-10

--- a/configs/resident/trip_destination_sample.csv
+++ b/configs/resident/trip_destination_sample.csv
@@ -5,8 +5,8 @@ Description,Expression,work,univ,school,escort,shopping,eatout,othmaint,social,o
 ,_od_bikeL@odt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
 ,_dp_bikeL@dpt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
 #,,,,,,,,,,,
-size term,"@np.log1p(size_terms.get(df.dest_maz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",1,1,1,1,1,1,1,1,1,1
-no attractions,"@size_terms.get(df.dest_maz, df.purpose) == 0 # sharrow: size_terms['sizearray'] == 0",-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
+size term,"@np.log1p(size_terms.get(df.alt_dest, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",1,1,1,1,1,1,1,1,1,1
+no attractions,"@size_terms.get(df.alt_dest, df.purpose) == 0 # sharrow: size_terms['sizearray'] == 0",-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
 #,,,,,,,,,,,
 ,"@df.walkTour * (np.where(_od_DIST > df.max_walk_distance,1,0) + np.where(_dp_DIST > df.max_walk_distance,1,0))",-10,-10,-10,-10,-10,-10,-10,-10,-10,-10
 ,@df.walkTour * (_od_DIST  +  _dp_DIST),-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5

--- a/configs/resident/trip_destination_sample.csv
+++ b/configs/resident/trip_destination_sample.csv
@@ -5,8 +5,8 @@ Description,Expression,work,univ,school,escort,shopping,eatout,othmaint,social,o
 ,_od_bikeL@odt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
 ,_dp_bikeL@dpt_skims['BIKE_LOGSUM'],1,1,1,1,1,1,1,1,1,1
 #,,,,,,,,,,,
-size term,"@np.log1p(size_terms.get(df.dest_taz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",1,1,1,1,1,1,1,1,1,1
-no attractions,"@size_terms.get(df.dest_taz, df.purpose) == 0 # sharrow: size_terms['sizearray'] == 0",-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
+size term,"@np.log1p(size_terms.get(df.dest_maz, df.purpose)) # sharrow: np.log1p(size_terms['sizearray'])",1,1,1,1,1,1,1,1,1,1
+no attractions,"@size_terms.get(df.dest_maz, df.purpose) == 0 # sharrow: size_terms['sizearray'] == 0",-999,-999,-999,-999,-999,-999,-999,-999,-999,-999
 #,,,,,,,,,,,
 ,"@df.walkTour * (np.where(_od_DIST > df.max_walk_distance,1,0) + np.where(_dp_DIST > df.max_walk_distance,1,0))",-10,-10,-10,-10,-10,-10,-10,-10,-10,-10
 ,@df.walkTour * (_od_DIST  +  _dp_DIST),-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5


### PR DESCRIPTION
Alternative implementation for #11 

Trip destination micro-mobility access time get assigned in the alternatives preprocessor now instead of when calculating utilities.

Requires code updates in https://github.com/ActivitySim/activitysim/pull/865