### PR TITLE
Settings Checker for Extensions

### DIFF
--- a/configs/resident/settings.yaml
+++ b/configs/resident/settings.yaml
@@ -154,6 +154,8 @@ distributed_time_factor_nonwork_stddev: 0.6
 distributed_time_factor_min: 0.1
 distributed_time_factor_max: 10
 
+check_model_settings: True
+
 models:
   ### mp_init_proto_pop (single process)
   - initialize_proto_population # Separate step so proto tables can be split for multiprocess.

--- a/configs/resident/settings_mp.yaml
+++ b/configs/resident/settings_mp.yaml
@@ -15,7 +15,9 @@ memory_profile: False
 # (Shadow pricing requires fail_fast setting in multiprocessing mode)
 fail_fast: True
 
-resume_after: 
+resume_after:
+
+check_model_settings: True
 
 models:
   ### mp_init_proto_pop (single process)

--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -4,3 +4,4 @@ from . import external_location_choice
 from . import transponder_ownership
 from . import airport_returns
 from . import adjust_auto_operating_cost
+from . import settings_checker

--- a/extensions/settings_checker.py
+++ b/extensions/settings_checker.py
@@ -1,0 +1,60 @@
+from .av_ownership import AVOwnershipSettings
+from .external_identification import ExternalIdentificationSettings
+from .transponder_ownership import TransponderOwnershipSettings
+
+from activitysim.core.configuration.base import PydanticReadable
+from activitysim.core.configuration.logit import (
+    TourLocationComponentSettings,
+    TourModeComponentSettings,
+)
+from activitysim.core.workflow import State
+
+
+
+### SETTINGS FORMAT ###
+### {"<model_name>": {"settings_cls": <PydanticSettings Object>, "settings_file": "<name of YAML file"}}
+### If a specific Pydantic data model is not defined, map to PydanticReadable to expose .read_settings_file() method
+### If required, an alternate set of spec/coefficients to resolve together can be defined for a model using
+###    "spec_coefficient_keys": [{"spec": "OUTBOUND_SPEC", "coefs": "OUTBOUND_COEFFICIENTS"}, ...]
+EXTENSION_CHECKER_SETTINGS = {
+    "airport_returns": {
+        "settings_cls": PydanticReadable,
+        "settings_file": "airport_returns.yaml"
+    },
+    "av_ownership": {
+        "settings_cls": AVOwnershipSettings,
+        "settings_file": "av_ownership.yaml"
+    },
+    "external_student_identification": {
+        "settings_cls": ExternalIdentificationSettings,
+        "settings_file": "external_student_identification.yaml"
+    },
+    "external_non_mandatory_tour_identification": {
+        "settings_cls": ExternalIdentificationSettings,
+        "settings_file": "external_non_mandatory_identification.yaml"
+    },
+    "external_joint_tour_identification": {
+        "settings_cls": ExternalIdentificationSettings,
+        "settings_file": "external_joint_tour_identification.yaml"
+    },
+    "external_school_location": {
+        "settings_cls": TourLocationComponentSettings,
+        "settings_file": "external_school_location.yaml"
+    },
+    "external_workplace_location": {
+        "settings_cls": TourLocationComponentSettings,
+        "settings_file": "external_workplace_location.yaml"
+    },
+    "external_non_mandatory_destination": {
+        "settings_cls": TourLocationComponentSettings,
+        "settings_file": "external_non_mandatory_destination.yaml"
+    },
+    "external_joint_tour_destination": {
+        "settings_cls": TourLocationComponentSettings,
+        "settings_file": "external_joint_tour_destination.yaml"
+    },
+    "transponder_ownership": {
+        "settings_cls": TransponderOwnershipSettings,
+        "settings_file": "transponder_ownership.yaml"
+    },
+}


### PR DESCRIPTION
As a follow on from [ActivitySim PR 950](https://github.com/ActivitySim/activitysim/pull/950), this pull request demonstrates a pattern for building a settings checker for extensions.

The key requirements are that users create a checker module in their extensions directory. This must be called `settings_checker.py` and contain a (dict) registry of settings called `EXTENSION_SETTER_CHECKINGS`. The general pattern established in core repository should be followed.