### PR TITLE
Removing unused 3-zone setting demographic_segments

### DIFF
--- a/configs/common/network_los.yaml
+++ b/configs/common/network_los.yaml
@@ -30,9 +30,3 @@ skim_time_periods:
     period_minutes: 30
     periods: [0, 6, 12, 25, 32, 48]  # time periods to match documentation
     labels: &skim_time_period_labels ['EA', 'AM', 'MD', 'PM', 'EV']
-
-demographic_segments: &demographic_segments
-  - &low_income_segment_id 0
-  - &high_income_segment_id 1
-
-

--- a/configs/common/outputs.yaml
+++ b/configs/common/outputs.yaml
@@ -892,7 +892,6 @@ persons:
     - num_shop_maint_tours
     - num_shop_maint_escort_tours
     - num_soc_discr_tours
-    - demographic_segment
     - time_distrib_mean_work
     - time_distrib_stddev_nonwork
     - time_distrib_mean_nonwork


### PR DESCRIPTION
Necessary for [#1056](https://github.com/ActivitySim/activitysim/pull/1056) to pass sandag test

Removes the unused demographic_segments network_los setting that was a holdover from previous 3-zone implementations.  Also removes the demographic_segment from the remove_columns setting in outputs.yaml as it also is not needed there either.